### PR TITLE
RoP: Add SAP defaults for REUSE exceptions

### DIFF
--- a/rop-sap-defaults/UseReuseDataProvider.config.yml
+++ b/rop-sap-defaults/UseReuseDataProvider.config.yml
@@ -1,0 +1,4 @@
+---
+repositoryExceptions:
+  - https://github.com/SAP/SapMachine
+  - https://github.com/SAP/async-profiler

--- a/rop-sap-defaults/UseReuseDataProvider.config.yml
+++ b/rop-sap-defaults/UseReuseDataProvider.config.yml
@@ -1,4 +1,5 @@
 ---
 repositoryExceptions:
   - https://github.com/SAP/SapMachine
+  - https://github.com/SAP/SapMachine-infrastructure
   - https://github.com/SAP/async-profiler

--- a/rop-sap-defaults/UseReuseDataProvider.config.yml
+++ b/rop-sap-defaults/UseReuseDataProvider.config.yml
@@ -1,5 +1,4 @@
 ---
 repositoryExceptions:
   - https://github.com/SAP/SapMachine
-  - https://github.com/SAP/SapMachine-infrastructure
   - https://github.com/SAP/async-profiler


### PR DESCRIPTION
Adds the SAP defaults for the REUSE data provider exceptions that will be introduced with https://github.com/SAP/fosstars-rating-core/pull/691
This PR should therefore not be merged before the other one. ;)