### PR TITLE
Exceptions for JMC repo

### DIFF
--- a/rop-sap-defaults/LicenseInfo.config.yml
+++ b/rop-sap-defaults/LicenseInfo.config.yml
@@ -11,3 +11,4 @@ repositoryExceptions:
   - https://github.com/SAP/abnf-test-tool
   - https://github.com/SAP/software-documentation-data-set-for-machine-translation
   - https://github.com/SAP/project-foxhound
+  - https://github.com/SAP/jmc

--- a/rop-sap-defaults/UseReuseDataProvider.config.yml
+++ b/rop-sap-defaults/UseReuseDataProvider.config.yml
@@ -3,3 +3,4 @@ repositoryExceptions:
   - https://github.com/SAP/SapMachine
   - https://github.com/SAP/async-profiler
   - https://github.com/SAP/project-foxhound
+  - https://github.com/SAP/jmc


### PR DESCRIPTION
Since JMC is a for of an already existing openjdk/jmc repo

 - Adding JMC repository as an exception for License check and reuse tool check.