### PR TITLE
Offer git user config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ and for committing the report and badge to the specified branch.
 The individual file names need to have the format `ProviderClassName.yaml` or `ProviderClassName.config.yaml`.
 As some data providers of the OSS Rules of Play rating require configuration files to work correctly, [SAP default configuration files](https://github.com/SAP/fosstars-rating-core-action/tree/main/rop-sap-defaults) are being used if the `oss-rules-of-play` rating is specified and no configuration URLs are passed to the action.
 
+### `git-user-name`
+
+**Optional** The git user name used when performing the report commit. Default `Fosstars`.
+
+### `git-user-email`
+
+**Optional** The git user email address used when performing the report commit. Default `fosstars@users.noreply.github.com`.
+
 ## How to use it
 
 Here is an example workflow that updates the report every day, or when a commit is pushed.

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,14 @@ inputs:
   data-provider-config-urls:
     description: "A comma-separated list of YAML config file URLs for data providers, file format: ProviderClassName.yaml"
     required: false
+  git-user-name:
+    description: "The git user name used when performing the report commit"
+    required: false
+    default: Fosstars
+  git-user-email: 
+    description: "The git user email address used when performing the report commit"
+    required: false
+    default: "fosstars@users.noreply.github.com"
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -36,6 +44,8 @@ runs:
     - ${{ inputs.fosstars-version }}
     - ${{ inputs.token }}
     - ${{ inputs.data-provider-config-urls }}
+    - ${{ inputs.git-user-name }}
+    - ${{ inputs.git-user-email }}
 branding:
   icon: 'award'  
   color: 'green'

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
   git-user-name:
     description: "The git user name used when performing the report commit"
     required: false
-    default: Fosstars
+    default: "Fosstars"
   git-user-email: 
     description: "The git user email address used when performing the report commit"
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,8 @@ BADGE_FILE=$4
 FOSSTARS_VERSION=$5
 TOKEN=$6
 DATA_PROVIDER_CONFIG_URLS=$7
+GIT_USER_NAME=$8
+GIT_USER_EMAIL=$9
 
 if [ "$RATING" = "" ]; then
     echo "Oops! No rating provided!"
@@ -33,6 +35,16 @@ fi
 
 if [ "$FOSSTARS_VERSION" = "" ]; then
     echo "Oops! No Fosstars version provided!"
+    exit 1
+fi
+
+if [ "$GIT_USER_NAME" = "" ]; then
+    echo "Oops! No git user name provided!"
+    exit 1
+fi
+
+if [ "$GIT_USER_EMAIL" = "" ]; then
+    echo "Oops! No git user email provided!"
     exit 1
 fi
 
@@ -122,8 +134,8 @@ wget -O $BADGE_FILE https://raw.githubusercontent.com/SAP/fosstars-rating-core-a
 git add $BADGE_FILE
 
 # Commit the report and the badge
-git config --global user.name "Fosstars"
-git config --global user.email "fosstars@users.noreply.github.com"
+git config --global user.name $GIT_USER_NAME
+git config --global user.email $GIT_USER_EMAIL
 
 git commit -m "Update Fosstars report" $REPORT_FILE $BADGE_FILE $RAW_RATING_FILE
 if [ $? -ne 0 ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -134,8 +134,8 @@ wget -O $BADGE_FILE https://raw.githubusercontent.com/SAP/fosstars-rating-core-a
 git add $BADGE_FILE
 
 # Commit the report and the badge
-git config --global user.name $GIT_USER_NAME
-git config --global user.email $GIT_USER_EMAIL
+git config --global user.name "$GIT_USER_NAME"
+git config --global user.email "$GIT_USER_EMAIL"
 
 git commit -m "Update Fosstars report" $REPORT_FILE $BADGE_FILE $RAW_RATING_FILE
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
This PRs offers the option to customize the committer with newly added input options:

-  `git-user-name`: The git user name used when performing the report commit
-  `git-user-email`: The git user email address used when performing the report commit